### PR TITLE
Fix issues

### DIFF
--- a/4.4-jdk8/Dockerfile
+++ b/4.4-jdk8/Dockerfile
@@ -50,9 +50,6 @@ RUN set -o errexit -o nounset                                                   
 	&& mkdir -p /home/apprunner/.gradle                                                                                \
 	&& mkdir -p /home/apprunner/playground                                                                             \
 	                                                                                                                   \
-	&& echo "Disabling Gradle daemon (because it doesn't work inside docker)"                                          \
-    && echo "org.gradle.daemon=false" > /home/apprunner/.gradle/gradle.properties                                      \
-	                                                                                                                   \
 	&& echo "Testing Gradle installation"                                                                              \
     && gradle --version                                                                                                \
                                                                                                                        \

--- a/4.4-jdk8/entry_point.sh
+++ b/4.4-jdk8/entry_point.sh
@@ -3,17 +3,34 @@
 export CONTAINER_GROUP_ID="${HOST_GROUP_ID:-1000}"
 export CONTAINER_USER_ID="${HOST_USER_ID:-1000}"
 
-# We first conditionally create the user's group
+########################################################################################################################
+# We disable Gradle's daemon via settings.                                                                             #
+# This step is done here (and not in the image building process) because the directory /home/apprunner/.gradle could   #
+# be mapped as an external volume when we want to make use of gradle's cache.                                          #
+########################################################################################################################
+if [[ ! -f /home/apprunner/.gradle/gradle.properties ]]; then
+    echo "org.gradle.daemon=false" > /home/apprunner/.gradle/gradle.properties                                         ;
+fi
+
+########################################################################################################################
+# We first conditionally create the user's group.                                                                      #
+# It's conditional because, depending on the host OS, the group could already exist inside the container.              #
+########################################################################################################################
 if grep -q "${CONTAINER_GROUP_ID}" /etc/group; then
     $(exit 0) ; # Group exists, nothing to do
 else
     addgroup -g "${CONTAINER_GROUP_ID}" apprunner                                                                      ;
 fi
 
-# We obtain the user's group name
+########################################################################################################################
+# We obtain the user's group name to use it at the time of creating users on the fly                                   #
+########################################################################################################################
 CONTAINER_GROUP_NAME=$(getent group "${CONTAINER_GROUP_ID}" | cut -d: -f1)
 
-# We conditionally create the user we'll use to execute commands
+########################################################################################################################
+# We conditionally create the user we'll use to execute commands.                                                      #
+# It's conditional because, depending on the host OS, the user could already exist inside the container.               #
+########################################################################################################################
 $(exit $?)                                                                                                          && \
 if getent passwd "${CONTAINER_USER_ID}" >/dev/null 2>&1; then
     $(exit 0) ; # User exists, nothing to do

--- a/README.md
+++ b/README.md
@@ -23,21 +23,12 @@ docker run                                                  \
 
 ## Extra tips
 
-As you work with this dockerized utility, you will find that it always tries to
-spawn a daemon in order to save resources on later builds. Because the way this
-container works, Gradle will fail doing this. It won't crash, but it's annoying
-to see the warning message every time.
+### Gradle's cache
 
-In order to disable the daemon spawning step, you can modify the command to
-something like this (notice the difference in the last line):
+In order to use the Gradle's cache, you can also mount a specific volume with
+the option `-v volume_name:/home/apprunner/.gradle`.
 
-```bash
-docker run                                                  \
-       --rm                                                 \
-       -it                                                  \
-       -v /home/user/sourcedir/:/home/apprunner/playground  \
-       -e HOST_USER_ID=$(id -u)                             \
-       -e HOST_GROUP_ID=$(id -g)                            \
-       adsmurai/gradle:4.4-jdk8                             \
-       gradle -Dorg.gradle.daemon=false build
-```
+We recommend to **NOT** mapping the equivalent directory inside the host
+(`-v /home/host_username/.gradle:/home/apprunner/.gradle`) because the custom
+entry point of this image explicitly disables the Gradle's daemon modifying
+the settings files inside this directory.


### PR DESCRIPTION
  - Document how to use Gradle's cache via mounting point
  - Document more verbosely the entry_point.sh script
  - Add extra step inside the entry_point.sh script to ensure that the Gradle's cache is disabled.